### PR TITLE
Disable RGA Hardstone Nuker while going to solve chests

### DIFF
--- a/src/main/java/com/jelly/MightyMiner/macros/macros/PowderMacro.java
+++ b/src/main/java/com/jelly/MightyMiner/macros/macros/PowderMacro.java
@@ -284,7 +284,8 @@ public class PowderMacro extends Macro {
                                 terminateTreasureSolving();
                                 break;
                         }
-                        if(MightyMiner.config.powNuker) RGANuker.enabled = true;
+                        if(MightyMiner.config.powNuker)
+                            RGANuker.enabled = true;
                         break;
 
                 }

--- a/src/main/java/com/jelly/MightyMiner/macros/macros/PowderMacro.java
+++ b/src/main/java/com/jelly/MightyMiner/macros/macros/PowderMacro.java
@@ -262,7 +262,9 @@ public class PowderMacro extends Macro {
                             case IDLE:
                                 if(BlockUtils.getPlayerLoc().equals(targetBlockPos))
                                     treasureState = TreasureState.SOLVING;
-                                else mineBaritone.goTo(targetBlockPos);
+                                else
+                                    RGANuker.enabled = false;
+                                    mineBaritone.goTo(targetBlockPos);
                                 break;
                             case FAILED:
                                 terminateTreasureSolving();
@@ -282,6 +284,7 @@ public class PowderMacro extends Macro {
                                 terminateTreasureSolving();
                                 break;
                         }
+                        RGANuker.enabled = true;
                         break;
 
                 }

--- a/src/main/java/com/jelly/MightyMiner/macros/macros/PowderMacro.java
+++ b/src/main/java/com/jelly/MightyMiner/macros/macros/PowderMacro.java
@@ -284,7 +284,7 @@ public class PowderMacro extends Macro {
                                 terminateTreasureSolving();
                                 break;
                         }
-                        RGANuker.enabled = true;
+                        if(MightyMiner.config.powNuker) RGANuker.enabled = true;
                         break;
 
                 }


### PR DESCRIPTION
A few bad things happen when the nuker mines while solving the chest:
1. Mines high enough where if chests spawn, particles to solve chest will not render particles and the macro won't even try to solve (out of reach with no way to solve)
2. High enough to let yogs spawn since the nuker while solving chests ignores the player set config of the nuker height
3. If multiple chests spawn, pathfinding bugs out (not sure what causes this but this might be a fix) and for a few minutes the macro will cause the player to just walk between the same 2 coords (usually right next to each other)

Gradle or something on my computer is broken so I am unable to compile and test this myself Also, not sure if changing the boolean value of RGANuker.enabled is the right way to enable/disable it Also, only like 80% sure they are placed in the right spot (idea is to disable as soon as the process of going to the chest begins and re enable it when it returns to its previous location before the chest spawned)