### PR TITLE
Sanitize slayer weapon names to prevent macro failure

### DIFF
--- a/src/main/java/com/jelly/mightyminerv2/config/MightyMinerConfig.java
+++ b/src/main/java/com/jelly/mightyminerv2/config/MightyMinerConfig.java
@@ -247,7 +247,7 @@ public class MightyMinerConfig extends Config {
             return;
         }
 
-        slayerWeapon = StringUtils.stripControlCodes(currentItem.getDisplayName());
+        slayerWeapon = StringUtils.stripControlCodes(currentItem.getDisplayName()).replaceAll("[^\\x20-\\x7E]", "");
         Logger.sendMessage("Slayer Weapon set to: " + currentItem.getDisplayName());
     };
 


### PR DESCRIPTION
Fixes an issue where weapons with dungeon stars break the macro at startup by removing non-printable ASCII characters from the weapon name.