### PR TITLE
v2.7.0-alpha-6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ baseGroup=com.jelly.mightyminerv2
 modName=MightyMinerV2
 modid=mightyminerv2
 mcVersion=1.8.9
-version=2.7.0-alpha-4
+version=2.7.0-alpha-6
 shouldRelease=false

--- a/src/main/java/com/jelly/mightyminerv2/config/MightyMinerConfig.java
+++ b/src/main/java/com/jelly/mightyminerv2/config/MightyMinerConfig.java
@@ -267,6 +267,13 @@ public class MightyMinerConfig extends Config {
     )
     public static boolean mobKillerInterpolate = true;
 
+    @Switch(
+            name = "Show Commission HUD outside mines", description = "Toggle HUD Visibility outside of dwarven mines",
+            category = COMMISSION,
+            subcategory = "Mob Killer"
+    )
+    public static boolean showDwarvenCommHUDOutside = true;
+
     @Exclude
     @HUD(
             name = "CommissionHUD",

--- a/src/main/java/com/jelly/mightyminerv2/config/MightyMinerConfig.java
+++ b/src/main/java/com/jelly/mightyminerv2/config/MightyMinerConfig.java
@@ -30,7 +30,7 @@ public class MightyMinerConfig extends Config {
     private transient static final File WAYPOINTS_FILE = new File(mc.mcDataDir, "mm_waypoints.json");
     private transient static final String GENERAL = "General";
     private transient static final String SCHEDULER = "Scheduler";
-    private transient static final String COMMISSION = "Commission";
+    private transient static final String COMMISSION = "Dwarven Commission";
     private transient static final String MINING_MACRO = "Mining Macro";
     private transient static final String ROUTE_MINER = "Route Miner";
     private transient static final String POWDER = "Gemstone Powder";
@@ -59,11 +59,13 @@ public class MightyMinerConfig extends Config {
             category = GENERAL,
             description = "Select the macro type you want to use",
             options = {
-                    "Commission",
-                    "Glacial Commissions",
-                    "Mining Macro",
-                    "Route Miner",
-                    "Gemstone Powder"
+                    "Dwarven Commission",
+                    "Mining Macro"
+//                    "Dwarven Commission",
+//                    "Glacial Commissions",
+//                    "Mining Macro",
+//                    "Route Miner",
+//                    "Gemstone Powder"
             },
             subcategory = "Macro"
     )
@@ -270,7 +272,7 @@ public class MightyMinerConfig extends Config {
     @Switch(
             name = "Show Commission HUD outside mines", description = "Toggle HUD Visibility outside of dwarven mines",
             category = COMMISSION,
-            subcategory = "Mob Killer"
+            subcategory = "HUD"
     )
     public static boolean showDwarvenCommHUDOutside = true;
 
@@ -335,6 +337,14 @@ public class MightyMinerConfig extends Config {
 
     //<editor-fold desc="Route Miner">
 
+    @Info(
+            text = "This feature is currently in development and currently does not function.",
+            type = InfoType.ERROR,
+            category = ROUTE_MINER,
+            size = 2
+    )
+    public static boolean ignored1 = true;
+
     @Dropdown(
             name = "Route Target", category = ROUTE_MINER, subcategory = "Route",
             description = "What you want to mine.",
@@ -377,6 +387,13 @@ public class MightyMinerConfig extends Config {
     //</editor-fold>
 
     //<editor-fold desc="Powder Macro">
+    @Info(
+            text = "This feature is currently in development and currently does not function.",
+            type = InfoType.ERROR,
+            category = POWDER,
+            size = 2
+    )
+    public static boolean ignored2 = true;
 
     @Switch(
             name = "Great Explorer Maxed", category = POWDER, subcategory = "General",
@@ -415,6 +432,13 @@ public class MightyMinerConfig extends Config {
     //</editor-fold>
 
     //<editor-fold desc="Route Builder">
+    @Info(
+            text = "This feature is currently in development and currently does not function.",
+            type = InfoType.ERROR,
+            category = ROUTE_BUILDER,
+            size = 2
+    )
+    public static boolean ignored3 = true;
 
     @KeyBind(
             name = "Enable RouteBuilder",

--- a/src/main/java/com/jelly/mightyminerv2/handler/GameStateHandler.java
+++ b/src/main/java/com/jelly/mightyminerv2/handler/GameStateHandler.java
@@ -37,6 +37,10 @@ public class GameStateHandler {
         return this.currentLocation.ordinal() < Location.values().length - 3;
     }
 
+    public boolean inDwarvenMines() {
+        return currentLocation == Location.DWARVEN_MINES;
+    }
+
     @SubscribeEvent
     public void onWorldUnload(WorldEvent.Unload event) {
         currentLocation = Location.KNOWHERE;

--- a/src/main/java/com/jelly/mightyminerv2/hud/CommissionHUD.java
+++ b/src/main/java/com/jelly/mightyminerv2/hud/CommissionHUD.java
@@ -46,7 +46,7 @@ public class CommissionHUD extends TextHud {
                 8,
                 new OneColor(0, 0, 0, 200),
                 true,
-                2,
+                1,
                 new OneColor(0, 255, 0, 255));
     }
 
@@ -79,7 +79,7 @@ public class CommissionHUD extends TextHud {
         if (commissionMacro.isEnabled()) {
             // Mining Info (Centered, bright green with brighter green solid line and added spaces)
             lines.add("§a§m---- §a  MINING INFO §a§m----"); // Brighter green separator
-            lines.add("  §f§a✰ §Target Commission:");
+            lines.add("  §f§a✰ §fTarget Commission:");
             lines.add("  §f" + commissionMacro.getCurrentCommission().getName());
             // Version (Bright green)
             lines.add(""); // Spacing

--- a/src/main/java/com/jelly/mightyminerv2/hud/CommissionHUD.java
+++ b/src/main/java/com/jelly/mightyminerv2/hud/CommissionHUD.java
@@ -4,6 +4,8 @@ import cc.polyfrost.oneconfig.config.annotations.Switch;
 import cc.polyfrost.oneconfig.config.core.OneColor;
 import cc.polyfrost.oneconfig.hud.TextHud;
 import com.jelly.mightyminerv2.MightyMiner;
+import com.jelly.mightyminerv2.config.MightyMinerConfig;
+import com.jelly.mightyminerv2.handler.GameStateHandler;
 import com.jelly.mightyminerv2.macro.impl.CommissionMacro.CommissionMacro;
 import lombok.Getter;
 
@@ -107,5 +109,14 @@ public class CommissionHUD extends TextHud {
                 seconds,
                 (!commissionMacro.isEnabled() ? " §7(Paused)" : "")
         );
+    }
+
+    @Override
+    protected boolean shouldShow() {
+        if (!super.shouldShow()) return false;
+        boolean macroTypeCondition = (MightyMinerConfig.macroType == 0);
+        boolean locationCondition = GameStateHandler.getInstance().inDwarvenMines() || MightyMinerConfig.showDwarvenCommHUDOutside;
+
+        return macroTypeCondition && locationCondition;
     }
 }

--- a/src/main/java/com/jelly/mightyminerv2/macro/MacroManager.java
+++ b/src/main/java/com/jelly/mightyminerv2/macro/MacroManager.java
@@ -25,18 +25,25 @@ public class MacroManager {
     private Minecraft mc = Minecraft.getMinecraft();
 
     public AbstractMacro getCurrentMacro() {
-        switch (MightyMinerConfig.macroType) {
-            case 1:
-                return GlacialMacro.getInstance();
-            case 2:
-                return MiningMacro.getInstance();
-            case 3:
-                return RouteMinerMacro.getInstance();
-            case 4:
-                return GemstonePowderMacro.getInstance();
-            default:
-                return CommissionMacro.getInstance();
+        if (MightyMinerConfig.macroType == 0) {
+            return CommissionMacro.getInstance();
+        } else if (MightyMinerConfig.macroType == 1) {
+            return MiningMacro.getInstance();
+        } else {
+            return CommissionMacro.getInstance();
         }
+//        switch (MightyMinerConfig.macroType) {
+//            case 1:
+//                return GlacialMacro.getInstance();
+//            case 2:
+//                return MiningMacro.getInstance();
+//            case 3:
+//                return RouteMinerMacro.getInstance();
+//            case 4:
+//                return GemstonePowderMacro.getInstance();
+//            default:
+//                return CommissionMacro.getInstance();
+//        }
     }
 
     public void toggle() {

--- a/src/main/java/com/jelly/mightyminerv2/macro/impl/CommissionMacro/states/MiningState.java
+++ b/src/main/java/com/jelly/mightyminerv2/macro/impl/CommissionMacro/states/MiningState.java
@@ -33,7 +33,7 @@ public class MiningState implements CommissionMacroState{
 
         String miningTool = MightyMinerConfig.miningTool;
         if (miningTool.toLowerCase().contains("drill") || InventoryUtil.getFullName(miningTool).contains("Drill")) {
-            log("Fuel detected: " + InventoryUtil.getDrillRemainingFuel(miningTool));
+            //log("Fuel detected: " + InventoryUtil.getDrillRemainingFuel(miningTool));
             if (InventoryUtil.getDrillRemainingFuel(miningTool) <= 100) {
                 log("Less than 100 fuel left in drill. Starting to refuel");
                 if(MightyMinerConfig.drillRefuel)


### PR DESCRIPTION
Fixed scoreboard typo and slimmed thickness of it's border ([Fix scoreboard](https://github.com/JellyLabScripts/MightyMiner/commit/c8e4e25dfca2a3fd619de7a2e1be3c3feaf89149))
Added a check to MiningState.java - if the currently looking at block does not equal the target block after 500ms, mines another block ([optimized the breaking state](https://github.com/JellyLabScripts/MightyMiner/commit/69c35b2d2f84321776f2737b638e09520483a7ed))
Removed non-functioning macro types from the config ([remove non-functioning macros from config](https://github.com/JellyLabScripts/MightyMiner/commit/51e90782ec203b2b489abc6cc32a2f2b7be11588))
Added option to disable Dwarven Commission HUD outside the Dwarven mines ([added option to disable dwarvenCommHUD](https://github.com/JellyLabScripts/MightyMiner/commit/1d27db1c1bc50ad474f0bda1c215acb70eeab3f6))