### PR TITLE
Failsafe fix + Add new failsafe + add new state to commission macro

### DIFF
--- a/src/main/java/com/jelly/mightyminerv2/failsafe/AbstractFailsafe.java
+++ b/src/main/java/com/jelly/mightyminerv2/failsafe/AbstractFailsafe.java
@@ -84,6 +84,7 @@ public abstract class AbstractFailsafe {
         TELEPORT,
         BEDROCK_CHECK,
         SLOT_CHANGE,
-        PLAYER_PROFILE_OPEN
+        PLAYER_PROFILE_OPEN,
+        NAME_MENTION
     }
 }

--- a/src/main/java/com/jelly/mightyminerv2/failsafe/FailsafeManager.java
+++ b/src/main/java/com/jelly/mightyminerv2/failsafe/FailsafeManager.java
@@ -38,7 +38,8 @@ public class FailsafeManager {
             KnockbackFailsafe.getInstance(),
             WorldChangeFailsafe.getInstance(),
             ProfileFailsafe.getInstance(),
-            ItemChangeFailsafe.getInstance()
+            ItemChangeFailsafe.getInstance(),
+            NameMentionFailsafe.getInstance()
         ));
     }
 

--- a/src/main/java/com/jelly/mightyminerv2/failsafe/impl/NameMentionFailsafe.java
+++ b/src/main/java/com/jelly/mightyminerv2/failsafe/impl/NameMentionFailsafe.java
@@ -1,0 +1,41 @@
+package com.jelly.mightyminerv2.failsafe.impl;
+
+import com.jelly.mightyminerv2.failsafe.AbstractFailsafe;
+import com.jelly.mightyminerv2.macro.MacroManager;
+import lombok.Getter;
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.client.event.ClientChatReceivedEvent;
+
+public class NameMentionFailsafe extends AbstractFailsafe {
+
+    @Getter
+    private static final NameMentionFailsafe instance = new NameMentionFailsafe();
+
+    @Override
+    public int getPriority() { return 10; }
+
+    @Override
+    public String getName() { return "NameMentionFailsafe"; }
+
+    @Override
+    public Failsafe getFailsafeType() { return Failsafe.NAME_MENTION; }
+
+    @Override
+    public boolean onChat(ClientChatReceivedEvent event) {
+        String playerName = mc.thePlayer.getName();
+        String message = event.message.getUnformattedText();
+        if (message.contains(playerName)) {
+            warn("Your name was mentioned in chat:");
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean react() {
+        MacroManager.getInstance().disable();
+        warn("Your name was mentioned in chat. Macro disabled.");
+        return true;
+    }
+}

--- a/src/main/java/com/jelly/mightyminerv2/failsafe/impl/NameMentionFailsafe.java
+++ b/src/main/java/com/jelly/mightyminerv2/failsafe/impl/NameMentionFailsafe.java
@@ -3,13 +3,17 @@ package com.jelly.mightyminerv2.failsafe.impl;
 import com.jelly.mightyminerv2.failsafe.AbstractFailsafe;
 import com.jelly.mightyminerv2.macro.MacroManager;
 import lombok.Getter;
-import net.minecraft.client.Minecraft;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class NameMentionFailsafe extends AbstractFailsafe {
 
     @Getter
     private static final NameMentionFailsafe instance = new NameMentionFailsafe();
+
+    private static final Pattern SENDER_NAME_PATTERN = Pattern.compile("^.*?(?<senderName>[a-zA-Z0-9_]+)§?f?:");
 
     @Override
     public int getPriority() { return 10; }
@@ -23,13 +27,20 @@ public class NameMentionFailsafe extends AbstractFailsafe {
     @Override
     public boolean onChat(ClientChatReceivedEvent event) {
         String playerName = mc.thePlayer.getName();
-        String message = event.message.getUnformattedText();
-        if (message.contains(playerName)) {
-            warn("Your name was mentioned in chat:");
-            return true;
-        }
+        String unformattedMessage = event.message.getUnformattedText();
 
-        return false;
+        String senderName = null;
+        Matcher matcher = SENDER_NAME_PATTERN.matcher(unformattedMessage);
+        if (matcher.find()) { senderName = matcher.group("senderName"); }
+
+        if (senderName != null && senderName.equalsIgnoreCase(playerName)) { return false; }
+
+        if (unformattedMessage.toLowerCase().contains(playerName.toLowerCase() + " invited ")) { return false; }
+
+        //if (unformattedMessage.toLowerCase().contains("has invited you to join their party!")) { notify() }
+
+        Pattern mentionPattern = Pattern.compile("\\b" + Pattern.quote(playerName) + "\\b", Pattern.CASE_INSENSITIVE);
+        return mentionPattern.matcher(unformattedMessage).find();
     }
 
     @Override

--- a/src/main/java/com/jelly/mightyminerv2/macro/impl/CommissionMacro/CommissionMacro.java
+++ b/src/main/java/com/jelly/mightyminerv2/macro/impl/CommissionMacro/CommissionMacro.java
@@ -6,6 +6,7 @@ import com.jelly.mightyminerv2.feature.FeatureManager;
 import com.jelly.mightyminerv2.hud.CommissionHUD;
 import com.jelly.mightyminerv2.macro.AbstractMacro;
 import com.jelly.mightyminerv2.macro.impl.CommissionMacro.states.CommissionMacroState;
+import com.jelly.mightyminerv2.macro.impl.CommissionMacro.states.NewLobbyState;
 import com.jelly.mightyminerv2.macro.impl.CommissionMacro.states.StartingState;
 import com.jelly.mightyminerv2.macro.impl.CommissionMacro.states.WarpingState;
 import com.jelly.mightyminerv2.util.CommissionUtil;
@@ -132,13 +133,14 @@ public class CommissionMacro extends AbstractMacro {
 
     @Override
     public void onTablistUpdate(UpdateTablistEvent event) {
-        if (!this.isEnabled() || currentState instanceof WarpingState) {
+        if (!this.isEnabled() || currentState instanceof WarpingState || currentState instanceof NewLobbyState) {
             return;
         }
 
         List<Commission> comms = CommissionUtil.getCurrentCommissionsFromTablist();
         if (comms.isEmpty()) {
             log("Cannot find commissions!");
+            return;
         }
         setCurrentCommission(comms.get(0));
     }

--- a/src/main/java/com/jelly/mightyminerv2/macro/impl/CommissionMacro/states/NewLobbyState.java
+++ b/src/main/java/com/jelly/mightyminerv2/macro/impl/CommissionMacro/states/NewLobbyState.java
@@ -79,7 +79,6 @@ public class NewLobbyState implements CommissionMacroState {
 
     @Override
     public void onEnd(CommissionMacro macro) {
-        autoWarp.stop();
         delayClock.reset();
         log("Ending NewLobbyState");
     }

--- a/src/main/java/com/jelly/mightyminerv2/macro/impl/CommissionMacro/states/NewLobbyState.java
+++ b/src/main/java/com/jelly/mightyminerv2/macro/impl/CommissionMacro/states/NewLobbyState.java
@@ -1,0 +1,96 @@
+package com.jelly.mightyminerv2.macro.impl.CommissionMacro.states;
+
+import com.jelly.mightyminerv2.feature.impl.AutoWarp;
+import com.jelly.mightyminerv2.macro.impl.CommissionMacro.CommissionMacro;
+import com.jelly.mightyminerv2.util.helper.Clock;
+import com.jelly.mightyminerv2.util.helper.location.Location;
+import com.jelly.mightyminerv2.util.helper.location.SubLocation;
+
+public class NewLobbyState implements CommissionMacroState {
+
+    private final AutoWarp autoWarp = AutoWarp.getInstance();
+    private final Clock delayClock = new Clock();
+    private WarpPhase currentPhase = WarpPhase.TO_HUB;
+
+    private static final long DELAY_MS_MIN = 3500;
+    private static final long DELAY_MS_MAX = 5000;
+    private long currentDelayDuration;
+
+    @Override
+    public void onStart(CommissionMacro macro) {
+        log("Starting NewLobbyState. Current phase: " + currentPhase);
+        delayClock.reset();
+        if (currentPhase == WarpPhase.TO_HUB) {
+            autoWarp.start(Location.HUB, null);
+        } else if (currentPhase == WarpPhase.TO_FORGE) {
+            autoWarp.start(null, SubLocation.THE_FORGE);
+        } else if (currentPhase == WarpPhase.DELAY_AFTER_HUB) {
+            currentDelayDuration = getRandomDelay();
+            delayClock.schedule(currentDelayDuration);
+            log("Delaying for " + (currentDelayDuration / 1000.0) + " seconds after Hub warp.");
+        }
+    }
+
+    @Override
+    public CommissionMacroState onTick(CommissionMacro macro) {
+        if (currentPhase == WarpPhase.TO_HUB || currentPhase == WarpPhase.TO_FORGE) {
+            if (autoWarp.isRunning()) {
+                return this;
+            }
+
+            if (autoWarp.hasSucceeded()) {
+                if (currentPhase == WarpPhase.TO_HUB) {
+                    log("Successfully warped to HUB. Proceeding to warp to THE_FORGE.");
+                    currentPhase = WarpPhase.TO_FORGE;
+                    autoWarp.start(null, SubLocation.THE_FORGE);
+                    return this;
+                } else if (currentPhase == WarpPhase.TO_FORGE) {
+                    log("Successfully warped to THE_FORGE. Resuming macro pathing.");
+                    return new StartingState();
+                }
+            } else {
+                switch (autoWarp.getFailReason()) {
+                    case NONE:
+                        macro.disable("Auto Warp failed during " + currentPhase + " phase (Hub/Forge sequence).");
+                        break;
+                    case FAILED_TO_WARP:
+                        macro.disable("Failed to warp to " + (currentPhase == WarpPhase.TO_HUB ? "Hub" : "Forge") + ". Disabling macro.");
+                        break;
+                    case NO_SCROLL:
+                        macro.disable("You don't have the warp scroll for " + (currentPhase == WarpPhase.TO_HUB ? "Hub" : "The Forge") + ". Disabling macro.");
+                        break;
+                }
+            }
+            return null;
+        }
+
+        if (currentPhase == WarpPhase.DELAY_AFTER_HUB) {
+            if (delayClock.passed()) {
+                log("Delay completed. Proceeding to warp to THE_FORGE.");
+                delayClock.reset();
+                currentPhase = WarpPhase.TO_FORGE;
+                autoWarp.start(null, SubLocation.THE_FORGE);
+            }
+            return this;
+        }
+
+        return null;
+    }
+
+    @Override
+    public void onEnd(CommissionMacro macro) {
+        autoWarp.stop();
+        delayClock.reset();
+        log("Ending NewLobbyState");
+    }
+
+    private long getRandomDelay() {
+        return (long) (DELAY_MS_MIN + (Math.random() * (DELAY_MS_MAX - DELAY_MS_MIN)));
+    }
+
+    private enum WarpPhase {
+        TO_HUB,
+        DELAY_AFTER_HUB,
+        TO_FORGE
+    }
+}

--- a/src/main/java/com/jelly/mightyminerv2/macro/impl/CommissionMacro/states/PathingState.java
+++ b/src/main/java/com/jelly/mightyminerv2/macro/impl/CommissionMacro/states/PathingState.java
@@ -61,7 +61,7 @@ public class PathingState implements CommissionMacroState{
                         "Note that this is usually temporary and caused by lags in the server.");
                 lastCommissionEmptyMessageTime = currentTime;
             }
-            return new StartingState();
+            return new WarpingState();
         }
 
         if (macro.getCurrentCommission() == Commission.COMMISSION_CLAIM && MightyMinerConfig.commClaimMethod == 1) {


### PR DESCRIPTION
[fix duplicate pickaxe causing ItemChangeFailsafe.java to trigger](https://github.com/JellyLabScripts/MightyMiner/commit/03c1439e3f7ed856ea77ca8b58cee541086e3129) → Fixed bug reported in discord. (Multiple identical pickaxes caused the failsafe to incorrectly trigger)

[add NameMentionFailsafe.java](https://github.com/JellyLabScripts/MightyMiner/commit/84e6566bcbec47ea572e41c055f3f3e6475f06b3) → If someone mentions your name in chat it stops macro and notifies you. 

[warp to new lobby if pathfinding fails](https://github.com/JellyLabScripts/MightyMiner/commit/84f2a39cb068d7ca399e52de118e837d8641e896) → Added new state to commission macro - (newlobbystate) This gets a new mining lobby by warping to hub then back to the forge.