### PR TITLE
feat: (commission-drill-swap) added swapping drill before commision claim 

### DIFF
--- a/src/main/java/com/jelly/mightyminerv2/config/MightyMinerConfig.java
+++ b/src/main/java/com/jelly/mightyminerv2/config/MightyMinerConfig.java
@@ -216,6 +216,16 @@ public class MightyMinerConfig extends Config {
     )
     public static int commClaimMethod = 0;
 
+
+    @Switch(
+            name = "Swap before claiming commission",
+            description = "Swaps to the alternative mining tool before claiming the commission",
+            category = COMMISSION,
+            subcategory = "General"
+
+    )
+    public static boolean commSwapBeforeClaiming = true;
+
     @Switch(
             name = "Sprint During MobKiller", description = "Allow Sprinting while mobkiller is active (looks sussy with sprint)",
             category = GENERAL,


### PR DESCRIPTION
This pull request introduces a new feature to support swapping to an alternative mining tool before and after claiming commissions in the `MightyMiner` application. It also includes updates to the state management and configuration to accommodate this feature.

### New Feature: Alternative Mining Tool Swapping
* Added a new configuration option `commSwapBeforeClaiming` in `MightyMinerConfig` to enable or disable swapping to an alternative mining tool before claiming commissions. The default value is set to `true`. (`[src/main/java/com/jelly/mightyminerv2/config/MightyMinerConfig.javaR219-R228](diffhunk://#diff-1e6a4850c42f5d7d7e07be931c1ab13bfedb18c6fec78332e4aedc7499a43c56R219-R228)`)
* Introduced new states `SWAPPING_TO_ALT` and `SWAPPING_BACK` in the `AutoCommissionClaim` feature to handle the logic for swapping tools before and after commission claiming. (`[src/main/java/com/jelly/mightyminerv2/feature/impl/AutoCommissionClaim.javaL253-R294](diffhunk://#diff-d625380928b99d1f676a0ca997749c8174ab37083a51539a8c4039b88577e0a4L253-R294)`)
* Added logic in `onTick` to:
  - Swap to the alternative mining tool before opening the commission GUI if `commSwapBeforeClaiming` is enabled. (`[src/main/java/com/jelly/mightyminerv2/feature/impl/AutoCommissionClaim.javaL149-R168](diffhunk://#diff-d625380928b99d1f676a0ca997749c8174ab37083a51539a8c4039b88577e0a4L149-R168)`)
  - Swap back to the primary mining tool after completing the commission if `commSwapBeforeClaiming` is enabled. (`[src/main/java/com/jelly/mightyminerv2/feature/impl/AutoCommissionClaim.javaR233-R264](diffhunk://#diff-d625380928b99d1f676a0ca997749c8174ab37083a51539a8c4039b88577e0a4R233-R264)`)
  
  # ^^ generated via copilot since we wanna documment so much