### PR TITLE
Route Miner Fixes + More

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MightyMinerV2 is a cutting-edge mining macro designed specifically for Hypixel S
 - **Glacial Macro**: Experimental!
 - **Route Mining Macro**: Experimental!
 - **Powder Macro**: Re-release soon!
-
+ 
 ### Upcoming Features:
 Our dedicated development team is actively working on integrating more features, including but not limited to:
 - Advanced gemstone mining automation.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ baseGroup=com.jelly.mightyminerv2
 modName=MightyMinerV2
 modid=mightyminerv2
 mcVersion=1.8.9
-version=2.7.3
+version=2.7.3-pre1
 shouldRelease=true

--- a/src/main/java/com/jelly/mightyminerv2/config/MightyMinerConfig.java
+++ b/src/main/java/com/jelly/mightyminerv2/config/MightyMinerConfig.java
@@ -443,6 +443,9 @@ public class MightyMinerConfig extends Config {
     @Switch(name = "Mine Topaz", category = ROUTE_MINER, subcategory = "Targets")
     public static boolean routeMineTopaz = false;
 
+    @Switch(name = "Mine Dwarven Ore", category = ROUTE_MINER, subcategory = "Targets")
+    public static boolean routeMineDwarvenOre = false;
+
     @Switch(name = "Mine Ore", category = ROUTE_MINER, subcategory = "Targets")
     public static boolean routeMineOre = false;
 

--- a/src/main/java/com/jelly/mightyminerv2/feature/impl/BlockMiner/BlockMiner.java
+++ b/src/main/java/com/jelly/mightyminerv2/feature/impl/BlockMiner/BlockMiner.java
@@ -55,10 +55,15 @@ public class BlockMiner extends AbstractFeature {
     public enum PickaxeAbilityState {
         AVAILABLE, UNAVAILABLE,
     }
+
     @Getter
     @Setter
-    private PickaxeAbilityState pickaxeAbilityState;
-    
+    private PickaxeAbilityState pickaxeAbilityState = PickaxeAbilityState.AVAILABLE;
+
+    @Getter
+    @Setter
+    private long lastAbilityUse = System.currentTimeMillis();
+
     @Getter
     @Setter
     private BlockMinerError error = BlockMinerError.NONE;
@@ -151,7 +156,7 @@ public class BlockMiner extends AbstractFeature {
             error = BlockMinerError.NO_TARGET_BLOCKS;
             return;
         }
-        
+
         // Build priority mapping for block selection
         for (int i = 0; i < blocksToMine.length; i++) {
             for (int j : blocksToMine[i].stateIds) {
@@ -164,7 +169,6 @@ public class BlockMiner extends AbstractFeature {
         this.pickaxeAbility = pickaxeAbility;
         this.enabled = true;
         this.error = BlockMinerError.NONE;
-        this.pickaxeAbilityState = PickaxeAbilityState.AVAILABLE;
         this.retryActivatePickaxeAbility = 0;
         targetParticlePos = null;
         
@@ -176,11 +180,14 @@ public class BlockMiner extends AbstractFeature {
 
     @Override
     public void stop() {
-        if(currentState != null)
+        if (currentState != null)
             currentState.onEnd(this);
+
         super.stop();
         KeyBindUtil.releaseAllExcept();
 
+        // Clear the block priority to prevent issues when changing a route mining target
+        blockPriority.clear();
     }
 
     @SubscribeEvent

--- a/src/main/java/com/jelly/mightyminerv2/feature/impl/BlockMiner/states/ApplyAbilityState.java
+++ b/src/main/java/com/jelly/mightyminerv2/feature/impl/BlockMiner/states/ApplyAbilityState.java
@@ -50,7 +50,7 @@ public class ApplyAbilityState implements BlockMinerState {
         if (BlockMiner.getInstance().getPickaxeAbility() == BlockMiner.PickaxeAbility.PICKOBULUS) {
             final BlockPos blueWool = getFarthestBlueWool();
 
-            if(blueWool == null) {
+            if (blueWool == null) {
                 log("Cannot find blue wool. Skipping the rotation.");
                 return;
             }
@@ -62,11 +62,11 @@ public class ApplyAbilityState implements BlockMinerState {
                 blueWool.getZ() + 0.5
             );
 
-            if(!points.isEmpty()) {
+            if (!points.isEmpty()) {
                 targetPoint = points.get(0);
             }
 
-            if(targetPoint != null) {
+            if (targetPoint != null) {
                 log("Rotating to blue wool");
                 RotationHandler.getInstance().easeTo(new RotationConfiguration(
                         AngleUtil.getRotation(targetPoint),
@@ -77,19 +77,19 @@ public class ApplyAbilityState implements BlockMinerState {
         }
 
         // Release all keys to prepare for the right click
-        if(Minecraft.getMinecraft().currentScreen == null) {
+        if (Minecraft.getMinecraft().currentScreen == null) {
             KeyBindUtil.releaseAllExcept();
         }
     }
 
     @Override
     public BlockMinerState onTick(BlockMiner blockMiner) {
-
         // If the first timer has ended and the player is not rotating, press right-click
         if (timer1.isScheduled() && timer1.passed() && !RotationHandler.getInstance().isEnabled()) {
             timer1.reset();
             timer2.reset();
             timer2.schedule(COOLDOWN);
+            blockMiner.setLastAbilityUse(System.currentTimeMillis());
             KeyBindUtil.rightClick();
         }
 

--- a/src/main/java/com/jelly/mightyminerv2/feature/impl/BlockMiner/states/StartingState.java
+++ b/src/main/java/com/jelly/mightyminerv2/feature/impl/BlockMiner/states/StartingState.java
@@ -1,5 +1,6 @@
 package com.jelly.mightyminerv2.feature.impl.BlockMiner.states;
 
+import com.jelly.mightyminerv2.config.MightyMinerConfig;
 import com.jelly.mightyminerv2.feature.impl.BlockMiner.BlockMiner;
 
 /**
@@ -21,11 +22,14 @@ public class StartingState implements BlockMinerState {
     }
 
     private boolean canUsePickaxeAbility(BlockMiner miner) {
+        if (System.currentTimeMillis() - miner.getLastAbilityUse() > 120000) {
+            miner.setPickaxeAbilityState(BlockMiner.PickaxeAbilityState.AVAILABLE);
+        }
+
         boolean hasAbility = miner.getPickaxeAbility() != BlockMiner.PickaxeAbility.NONE;
-        boolean isCooledDown = System.currentTimeMillis() - miner.getLastAbilityUse() > 60000;
         boolean isAvailable = miner.getPickaxeAbilityState() == BlockMiner.PickaxeAbilityState.AVAILABLE;
 
-        return hasAbility && (isCooledDown || isAvailable);
+        return MightyMinerConfig.usePickaxeAbility && hasAbility && isAvailable;
     }
 
     @Override

--- a/src/main/java/com/jelly/mightyminerv2/feature/impl/BlockMiner/states/StartingState.java
+++ b/src/main/java/com/jelly/mightyminerv2/feature/impl/BlockMiner/states/StartingState.java
@@ -1,7 +1,6 @@
 package com.jelly.mightyminerv2.feature.impl.BlockMiner.states;
 
 import com.jelly.mightyminerv2.feature.impl.BlockMiner.BlockMiner;
-import com.jelly.mightyminerv2.config.MightyMinerConfig;
 
 /**
  * StartingState
@@ -18,15 +17,20 @@ public class StartingState implements BlockMinerState {
 
     @Override
     public BlockMinerState onTick(BlockMiner miner) {
-        if (BlockMiner.getInstance().getPickaxeAbility() != BlockMiner.PickaxeAbility.NONE
-                && miner.getPickaxeAbilityState() == BlockMiner.PickaxeAbilityState.AVAILABLE) {
-            return new ApplyAbilityState();
-        } else
-            return new ChoosingBlockState();
+        return canUsePickaxeAbility(miner) ? new ApplyAbilityState() : new ChoosingBlockState();
+    }
+
+    private boolean canUsePickaxeAbility(BlockMiner miner) {
+        boolean hasAbility = miner.getPickaxeAbility() != BlockMiner.PickaxeAbility.NONE;
+        boolean isCooledDown = System.currentTimeMillis() - miner.getLastAbilityUse() > 60000;
+        boolean isAvailable = miner.getPickaxeAbilityState() == BlockMiner.PickaxeAbilityState.AVAILABLE;
+
+        return hasAbility && (isCooledDown || isAvailable);
     }
 
     @Override
     public void onEnd(BlockMiner miner) {
         log("Exiting Starting State");
     }
+
 }

--- a/src/main/java/com/jelly/mightyminerv2/feature/impl/MouseUngrab.java
+++ b/src/main/java/com/jelly/mightyminerv2/feature/impl/MouseUngrab.java
@@ -9,6 +9,7 @@ public class MouseUngrab extends AbstractFeature {
 
     private static volatile MouseUngrab instance;
     private MouseHelper oldMouseHelper;
+    private boolean oldPauseOnLostFocus;
     private boolean mouseUngrabbed = false;
 
     public static MouseUngrab getInstance() {
@@ -28,6 +29,7 @@ public class MouseUngrab extends AbstractFeature {
         }
 
         oldMouseHelper = mc.mouseHelper;
+        oldPauseOnLostFocus = mc.gameSettings.pauseOnLostFocus;
         mc.mouseHelper.ungrabMouseCursor();
 
         mc.mouseHelper = new MouseHelper() {
@@ -44,6 +46,7 @@ public class MouseUngrab extends AbstractFeature {
             }
         };
 
+        mc.gameSettings.pauseOnLostFocus = false;
         mouseUngrabbed = true;
         log("Mouse ungrabbed successfully.");
     }
@@ -62,6 +65,7 @@ public class MouseUngrab extends AbstractFeature {
             mc.mouseHelper.grabMouseCursor();
         }
 
+        mc.gameSettings.pauseOnLostFocus = oldPauseOnLostFocus;
         mouseUngrabbed = false;
         log("Mouse regrabbed successfully.");
     }

--- a/src/main/java/com/jelly/mightyminerv2/feature/impl/MouseUngrab.java
+++ b/src/main/java/com/jelly/mightyminerv2/feature/impl/MouseUngrab.java
@@ -9,7 +9,6 @@ public class MouseUngrab extends AbstractFeature {
 
     private static volatile MouseUngrab instance;
     private MouseHelper oldMouseHelper;
-    private boolean oldPauseOnLostFocus;
     private boolean mouseUngrabbed = false;
 
     public static MouseUngrab getInstance() {
@@ -29,7 +28,6 @@ public class MouseUngrab extends AbstractFeature {
         }
 
         oldMouseHelper = mc.mouseHelper;
-        oldPauseOnLostFocus = mc.gameSettings.pauseOnLostFocus;
         mc.mouseHelper.ungrabMouseCursor();
 
         mc.mouseHelper = new MouseHelper() {
@@ -46,7 +44,6 @@ public class MouseUngrab extends AbstractFeature {
             }
         };
 
-        mc.gameSettings.pauseOnLostFocus = false;
         mouseUngrabbed = true;
         log("Mouse ungrabbed successfully.");
     }
@@ -65,7 +62,6 @@ public class MouseUngrab extends AbstractFeature {
             mc.mouseHelper.grabMouseCursor();
         }
 
-        mc.gameSettings.pauseOnLostFocus = oldPauseOnLostFocus;
         mouseUngrabbed = false;
         log("Mouse regrabbed successfully.");
     }

--- a/src/main/java/com/jelly/mightyminerv2/feature/impl/PathExecutor.java
+++ b/src/main/java/com/jelly/mightyminerv2/feature/impl/PathExecutor.java
@@ -249,6 +249,7 @@ public class PathExecutor {
                 dynamicPitch.schedule(1000);
             }
 
+
             // TODO: Implement back route miner
             RotationHandler.getInstance().easeTo(
                     new RotationConfiguration(

--- a/src/main/java/com/jelly/mightyminerv2/feature/impl/RouteBuilder.java
+++ b/src/main/java/com/jelly/mightyminerv2/feature/impl/RouteBuilder.java
@@ -12,6 +12,7 @@ import com.jelly.mightyminerv2.util.helper.route.WaypointType;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.InputEvent;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class RouteBuilder extends AbstractFeature {
@@ -69,8 +70,10 @@ public class RouteBuilder extends AbstractFeature {
 
         if (MightyMinerConfig.routeBuilderRemoveKeybind.isActive()) {
             Route selectedRoute = RouteHandler.getInstance().getSelectedRoute();
-            RouteWaypoint closest = selectedRoute.getClosest(PlayerUtil.getBlockStandingOn()).get();
-            int index = selectedRoute.indexOf(closest);
+            Optional<RouteWaypoint> closest = selectedRoute.getClosest(PlayerUtil.getBlockStandingOn());
+
+            if (!closest.isPresent()) return;
+            int index = selectedRoute.indexOf(closest.get());
 
             if (index == -1) {
                 return;

--- a/src/main/java/com/jelly/mightyminerv2/handler/RotationHandler.java
+++ b/src/main/java/com/jelly/mightyminerv2/handler/RotationHandler.java
@@ -26,6 +26,7 @@ public class RotationHandler {
     private final Minecraft mc = Minecraft.getMinecraft();
     private final Angle startRotation = new Angle(0f, 0f);
     private final Random random = new Random();
+    @Getter
     private boolean enabled;
     private long startTime;
     private long endTime;
@@ -40,6 +41,7 @@ public class RotationHandler {
     private int randomMultiplier1 = 1;
     private int randomMultiplier2 = 1;
 
+    @Getter
     private boolean followingTarget = false;
     private boolean stopRequested = false;
 
@@ -215,14 +217,6 @@ public class RotationHandler {
             return (long) (time * 1.1);
         }
         return (long) (time * 1.0);
-    }
-
-    public boolean isEnabled() {
-        return this.enabled;
-    }
-
-    public boolean isFollowingTarget() {
-        return this.followingTarget;
     }
 
     public void stopFollowingTarget() {

--- a/src/main/java/com/jelly/mightyminerv2/handler/RouteHandler.java
+++ b/src/main/java/com/jelly/mightyminerv2/handler/RouteHandler.java
@@ -57,7 +57,7 @@ public class RouteHandler {
         }
 
         final RouteWaypoint waypoint = new RouteWaypoint(block, method);
-        if (this.selectedRoute.indexOf(waypoint) != -1) return;
+        if (this.selectedRoute.indexOf(waypoint) != -1 && method != WaypointType.MINE) return;
 
         this.selectedRoute.insert(waypoint);
         this.markDirty();

--- a/src/main/java/com/jelly/mightyminerv2/macro/MacroManager.java
+++ b/src/main/java/com/jelly/mightyminerv2/macro/MacroManager.java
@@ -4,6 +4,7 @@ import com.jelly.mightyminerv2.config.MightyMinerConfig;
 import com.jelly.mightyminerv2.event.PacketEvent;
 import com.jelly.mightyminerv2.event.UpdateTablistEvent;
 import com.jelly.mightyminerv2.feature.FeatureManager;
+import com.jelly.mightyminerv2.feature.impl.BlockMiner.BlockMiner;
 import com.jelly.mightyminerv2.feature.impl.MouseUngrab;
 import com.jelly.mightyminerv2.macro.impl.CommissionMacro.CommissionMacro;
 import com.jelly.mightyminerv2.macro.impl.GlacialMacro.GlacialMacro;
@@ -54,6 +55,8 @@ public class MacroManager {
         FeatureManager.getInstance().enableAll();
         this.currentMacro = this.getCurrentMacro();
         send(this.currentMacro.getName() + " Enabled");
+
+        BlockMiner.getInstance().setPickaxeAbilityState(BlockMiner.PickaxeAbilityState.AVAILABLE);
         this.currentMacro.enable();
     }
 

--- a/src/main/java/com/jelly/mightyminerv2/macro/impl/RouteMiner/RouteMinerMacro.java
+++ b/src/main/java/com/jelly/mightyminerv2/macro/impl/RouteMiner/RouteMinerMacro.java
@@ -59,7 +59,7 @@ public class RouteMinerMacro extends AbstractMacro {
             return;
         }
 
-        BlockMiner.getInstance().setWaitThreshold(50);
+        BlockMiner.getInstance().setWaitThreshold(0);
         Optional<RouteWaypoint> waypoint = route.getClosest(PlayerUtil.getBlockStandingOn());
         waypoint.ifPresent(routeWaypoint -> routeIndex = route.indexOf(routeWaypoint));
 

--- a/src/main/java/com/jelly/mightyminerv2/macro/impl/RouteMiner/RouteMinerMacro.java
+++ b/src/main/java/com/jelly/mightyminerv2/macro/impl/RouteMiner/RouteMinerMacro.java
@@ -128,6 +128,13 @@ public class RouteMinerMacro extends AbstractMacro {
     public MineableBlock[] getBlocksToMine() {
         List<MineableBlock> blocksList = new ArrayList<>();
 
+        if (MightyMinerConfig.routeMineDwarvenOre) {
+            blocksList.add(MineableBlock.GRAY_MITHRIL);
+            blocksList.add(MineableBlock.GREEN_MITHRIL);
+            blocksList.add(MineableBlock.BLUE_MITHRIL);
+            blocksList.add(MineableBlock.TITANIUM);
+        }
+
         if (MightyMinerConfig.routeMineGemstone) {
             blocksList.add(MineableBlock.AMBER);
             blocksList.add(MineableBlock.AMETHYST);

--- a/src/main/java/com/jelly/mightyminerv2/macro/impl/RouteMiner/states/MovingState.java
+++ b/src/main/java/com/jelly/mightyminerv2/macro/impl/RouteMiner/states/MovingState.java
@@ -28,6 +28,7 @@ public class MovingState implements RouteMinerMacroState {
     private RouteWaypoint routeTarget;
 
     private final Clock etherWarpDelay = new Clock();
+    private boolean rotating = true;
     private boolean hasClicked = false;
     private BlockPos lastPosition = null;
 
@@ -58,7 +59,11 @@ public class MovingState implements RouteMinerMacroState {
     public RouteMinerMacroState onTick(RouteMinerMacro macro) {
         switch (routeTarget.getTransportMethod()) {
             case ETHERWARP:
-                if (RotationHandler.getInstance().isEnabled()) {
+                if (rotating) {
+                    if (!RotationHandler.getInstance().isEnabled()) {
+                        rotating = false;
+                    }
+
                     return this;
                 }
 

--- a/src/main/java/com/jelly/mightyminerv2/mixin/render/MixinEntityRenderer.java
+++ b/src/main/java/com/jelly/mightyminerv2/mixin/render/MixinEntityRenderer.java
@@ -1,0 +1,18 @@
+package com.jelly.mightyminerv2.mixin.render;
+
+import com.jelly.mightyminerv2.macro.MacroManager;
+import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.client.settings.GameSettings;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(EntityRenderer.class)
+public class MixinEntityRenderer {
+
+    @Redirect(method = "updateCameraAndRender", at = @At(value = "FIELD", target = "Lnet/minecraft/client/settings/GameSettings;pauseOnLostFocus:Z"))
+    private boolean redirectPauseOnLostFocus(GameSettings gameSettings) {
+        return gameSettings.pauseOnLostFocus && !MacroManager.getInstance().isRunning();
+    }
+
+}

--- a/src/main/resources/mixins.mightyminerv2.json
+++ b/src/main/resources/mixins.mightyminerv2.json
@@ -21,6 +21,7 @@
     "client.MixinChunkProviderClient",
     "client.MixinEntityPlayerSP",
     "network.MixinNetHandlerPlayClient",
+    "render.MixinEntityRenderer",
     "render.MixinModelBiped"
   ]
 }


### PR DESCRIPTION
- Reduced wait threshold (improves speed)
- Pause on lost focus fix found in MixinEntityRenderer 
- Added support for mithril routes
- Allow MINE waypoint to be same block as other waypoints
- Made BlockMiner not start ability at each new waypoint, and properly track ability cooldown (i think)

TODO:
- Add better pickobulus support