### PR TITLE
fix(routebuilder): prevent crash when removing node

### DIFF
--- a/src/main/java/com/jelly/mightyminerv2/feature/impl/RouteBuilder.java
+++ b/src/main/java/com/jelly/mightyminerv2/feature/impl/RouteBuilder.java
@@ -69,6 +69,11 @@ public class RouteBuilder extends AbstractFeature {
 
         if (MightyMinerConfig.routeBuilderRemoveKeybind.isActive()) {
             Route selectedRoute = RouteHandler.getInstance().getSelectedRoute();
+            
+            if (selectedRoute.isEmpty()) {
+                return;
+            }
+            
             RouteWaypoint closest = selectedRoute.getClosest(PlayerUtil.getBlockStandingOn()).get();
             int index = selectedRoute.indexOf(closest);
 


### PR DESCRIPTION
Fixed an issue where attempting to remove a node when none existed in the route would cause a crash.