### PR TITLE
Added Mithril Priority to Mining Macro

### DIFF
--- a/src/main/java/com/jelly/mightyminerv2/config/MightyMinerConfig.java
+++ b/src/main/java/com/jelly/mightyminerv2/config/MightyMinerConfig.java
@@ -406,6 +406,38 @@ public class MightyMinerConfig extends Config {
             subcategory = "Mithril Macro"
     )
     public static boolean mineTitanium = true;
+    
+    @Number(
+            name = "Default Priority - Gray Mithril",
+            category = MINING_MACRO,
+            subcategory = "Mithril Priority",
+            min = 0, max = 30
+    )
+    public static int mithrilPriorityGrayDefault = 1;
+
+    @Number(
+            name = "Default Priority - Green Mithril",
+            category = MINING_MACRO,
+            subcategory = "Mithril Priority",
+            min = 0, max = 30
+    )
+    public static int mithrilPriorityGreenDefault = 3;
+
+    @Number(
+            name = "Default Priority - Blue Mithril",
+            category = MINING_MACRO,
+            subcategory = "Mithril Priority",
+            min = 0, max = 30
+    )
+    public static int mithrilPriorityBlueDefault = 6;
+
+    @Number(
+            name = "Default Priority - Titanium",
+            category = MINING_MACRO,
+            subcategory = "Mithril Priority",
+            min = 0, max = 30
+    )
+    public static int mithrilPriorityTitaniumDefault = 10;
 
     //</editor-fold>
 

--- a/src/main/java/com/jelly/mightyminerv2/macro/impl/MiningMacro/MiningMacro.java
+++ b/src/main/java/com/jelly/mightyminerv2/macro/impl/MiningMacro/MiningMacro.java
@@ -200,13 +200,12 @@ public class MiningMacro extends AbstractMacro {
     private int[] determinePriority() {
         if (MightyMinerConfig.oreType == 0) {
             return new int[]{
-                    MightyMinerConfig.mineGrayMithril ? 1 : 0,
-                    MightyMinerConfig.mineGreenMithril ? 1 : 0,
-                    MightyMinerConfig.mineBlueMithril ? 1 : 0,
-                    MightyMinerConfig.mineTitanium ? 10 : 0
+                    MightyMinerConfig.mineGrayMithril ? MightyMinerConfig.mithrilPriorityGrayDefault : 0,
+                    MightyMinerConfig.mineGreenMithril ? MightyMinerConfig.mithrilPriorityGreenDefault : 0,
+                    MightyMinerConfig.mineBlueMithril ? MightyMinerConfig.mithrilPriorityBlueDefault : 0,
+                    MightyMinerConfig.mineTitanium ? MightyMinerConfig.mithrilPriorityTitaniumDefault : 0
             };
         }
         return new int[]{1, 1, 1, 1};
     }
-
 }


### PR DESCRIPTION
## Description
- Added config properties (so that the priority is easily changeable from the UI)
    - In the UI this can be found on the Mining Macro tab
- Modified the Mining Macro to use the values from the config
- Made a default priority as follows (most to least prioritized)
    - Titanium
    - Blue Wool
    - Prismarine
    - Gray Wool

## Testing
- The mod is building correctly
- The functionality has been tested and works correctly

---
This pull request can be merged and a new release can be uploaded.

### ENJOY!